### PR TITLE
version/1.1.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- fix createReState select to return a hook
 - useReStateSelector is equal params
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [1.1.16] - 2021-06-23
+
 ### Breaking changes
 
 - new createReStateSelect is CreateGetReState (is the same old interface)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,36 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [Unreleased]
+
+### Breaking changes
+
+- new createReStateSelect is CreateGetReState (is the same old interface)
+
+### Added
+
+- add change log
+- add createGetReState (like old createReStateSelect)
+- add advanced example
+- export all types
+
+### Fixed
+
+- useReStateSelector is equal params
+
+### Changed
+
+- convert createReStateSelect to observe one state in the store
+- Update Readme
+- Update types in documentation - useReStateSelector
+
+## [1.1.14] - 2021-05-19
+
+### Added
+
+- add reStateSelect
+- example
+- docs
+- advanced example
+- demo basic usage

--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ yarn add @raulpesilva/re-state
 ## TODO
 
 - [x] - Examples
+- [x] - Docs
 - [ ] - Tests
-- [ ] - Doc
 
 ## Simple Usage - [![Demo](https://badgen.net/badge/Demo/CodeSandbox/black)](https://codesandbox.io/s/basic-usage-re-state-86l06?file=/src/App.js)
 

--- a/README.md
+++ b/README.md
@@ -138,9 +138,10 @@ This method select any data from store and update when change
 import {useReStateSelector} from '@raulpesilva/re-state'
 import type { Muted } from './mutedState'
 import { key } from './mutedState'
+type Store = { [key]: Muted}
 
 export const MyComponent = () => {
-  const muted = useReStateSelector<Muted>(({muted}=> muted))
+  const muted = useReStateSelector<Store, Muted>(({muted}=> muted))
 
   return (
     <div>
@@ -191,9 +192,10 @@ export const toggleMute = () => muteDispatch(prev => !prev)
 ```tsx
 import type { Muted,toggleMute } from './mutedState'
 import { key } from './mutedState'
+type Store = { [key]: Muted}
 
 export const MyComponent = () => {
-  const muted = useReStateSelector<Muted>(({muted}=> muted))
+  const muted = useReStateSelector<Store,Muted>(({ muted }=> muted))
 
   return (
     <div>

--- a/docs/pages/examples/useReStateSelector.mdx
+++ b/docs/pages/examples/useReStateSelector.mdx
@@ -4,12 +4,14 @@ This method select any data from store and update when change
 
 ```tsx
 //MyComponent.tsx
-import {useReStateSelector} from '@raulpesilva/re-state'
+import { useReStateSelector } from '@raulpesilva/re-state'
 import type { Muted } from './mutedState'
 import { key } from './mutedState'
 
+type Store = { [key]: Muted }
+
 export const MyComponent = () => {
-  const muted = useReStateSelector<Muted>(({muted}=> muted))
+  const muted = useReStateSelector<Store>(({ muted }) => muted)
 
   return (
     <div>
@@ -20,5 +22,7 @@ export const MyComponent = () => {
 ```
 
 ```ts
-const result: any = useReStateSelector(selector: Function, equalityFn?: Function)
+type Selector<Store, DataToReturn = Store> = (store: Store) => DataToReturn
+
+const result: any = useReStateSelector(selector: Selector, equalityFn?: Function)
 ```

--- a/docs/pages/examples/useReStateSelector.mdx
+++ b/docs/pages/examples/useReStateSelector.mdx
@@ -11,7 +11,7 @@ import { key } from './mutedState'
 type Store = { [key]: Muted }
 
 export const MyComponent = () => {
-  const muted = useReStateSelector<Store>(({ muted }) => muted)
+  const muted = useReStateSelector<Store, Boolean>(({ muted }) => muted)
 
   return (
     <div>
@@ -22,7 +22,9 @@ export const MyComponent = () => {
 ```
 
 ```ts
+type Store = { MeyKey: Boolean }
+type DataToReturn = boolean
 type Selector<Store, DataToReturn = Store> = (store: Store) => DataToReturn
 
-const result: any = useReStateSelector(selector: Selector, equalityFn?: Function)
+const result: DataToReturn = useReStateSelector<Store,DataToReturn>(selector: Selector, equalityFn?: Function)
 ```

--- a/docs/pages/examples/useReStateSelector.mdx
+++ b/docs/pages/examples/useReStateSelector.mdx
@@ -4,14 +4,12 @@ This method select any data from store and update when change
 
 ```tsx
 //MyComponent.tsx
-import { useReStateSelector } from '@raulpesilva/re-state'
+import {useReStateSelector} from '@raulpesilva/re-state'
 import type { Muted } from './mutedState'
 import { key } from './mutedState'
 
-type Store = { [key]: Muted }
-
 export const MyComponent = () => {
-  const muted = useReStateSelector<Store>(({ muted }) => muted)
+  const muted = useReStateSelector<Muted>(({muted}=> muted))
 
   return (
     <div>
@@ -22,7 +20,5 @@ export const MyComponent = () => {
 ```
 
 ```ts
-type Selector<Store, DataToReturn = Store> = (store: Store) => DataToReturn
-
-const result: any = useReStateSelector(selector: Selector, equalityFn?: Function)
+const result: any = useReStateSelector(selector: Function, equalityFn?: Function)
 ```

--- a/examples/package.json
+++ b/examples/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@raulpesilva/re-state": "1.1.16-beta.1",
+    "@raulpesilva/re-state": "file:../dist",
     "@testing-library/jest-dom": "^5.11.4",
     "@testing-library/react": "^11.1.0",
     "@testing-library/user-event": "^12.1.10",

--- a/examples/package.json
+++ b/examples/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@raulpesilva/re-state": "1.1.16-beta.0",
+    "@raulpesilva/re-state": "1.1.16-beta.1",
     "@testing-library/jest-dom": "^5.11.4",
     "@testing-library/react": "^11.1.0",
     "@testing-library/user-event": "^12.1.10",

--- a/examples/package.json
+++ b/examples/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@raulpesilva/re-state": "^1.1.13",
+    "@raulpesilva/re-state": "1.1.16-beta.0",
     "@testing-library/jest-dom": "^5.11.4",
     "@testing-library/react": "^11.1.0",
     "@testing-library/user-event": "^12.1.10",

--- a/examples/src/components/AdvancedUsage/index.tsx
+++ b/examples/src/components/AdvancedUsage/index.tsx
@@ -1,14 +1,19 @@
 import styles from './index.module.css'
-import { addTodo, TodoItemProps, TodoList, toggleTodo } from '../../states'
-import { useReStateSelector } from '@raulpesilva/re-state'
+import { addTodo, TodoItemProps, TodoKey, toggleTodo } from '../../states'
+import type { TodoList } from '../../states'
+import { Selector, useReStateSelector } from '@raulpesilva/re-state'
 import { useRef } from 'react'
+
+type Store = { [TodoKey]: TodoList }
+
+const todosSelector: Selector<Store, TodoList> = ({ todos }) => todos
+const countFinishedTodoSelector: Selector<Store, number> = ({ todos }) =>
+  todos ? todos.filter(todo => todo.finished).length : 0
 
 export const AdvancedUsage = () => {
   const taskRef = useRef<HTMLInputElement>(null)
-  const todos = useReStateSelector<TodoList>(({ todos }) => todos ?? [])
-  const totalFinished = useReStateSelector<TodoList>(({ todos }) =>
-    todos ? todos.filter(todo => todo.finished).length : 0
-  )
+  const todos = useReStateSelector(todosSelector)
+  const totalFinished = useReStateSelector(countFinishedTodoSelector)
 
   const handleAddTodo = () => {
     if (taskRef.current?.value?.trim()) {

--- a/examples/src/components/AdvancedUsage/index.tsx
+++ b/examples/src/components/AdvancedUsage/index.tsx
@@ -1,25 +1,25 @@
-import styles from './index.module.css'
-import { addTodo, TodoItemProps, TodoKey, toggleTodo } from '../../states'
-import type { TodoList } from '../../states'
+import { useCallback, useRef } from 'react'
 import { Selector, useReStateSelector } from '@raulpesilva/re-state'
-import { useRef } from 'react'
+import type { TodoList } from '../../states'
+import { addTodo, TodoItemProps, TodoKey, toggleTodo } from '../../states'
+import styles from './index.module.css'
 
 type Store = { [TodoKey]: TodoList }
 
 const todosSelector: Selector<Store, TodoList> = ({ todos }) => todos
 const countFinishedTodoSelector: Selector<Store, number> = ({ todos }) =>
   todos ? todos.filter(todo => todo.finished).length : 0
+const countTodosSelector: Selector<Store, number> = ({ todos }) => todos.length ?? 0
 
 export const AdvancedUsage = () => {
   const taskRef = useRef<HTMLInputElement>(null)
-  const todos = useReStateSelector(todosSelector)
-  const totalFinished = useReStateSelector(countFinishedTodoSelector)
 
-  const handleAddTodo = () => {
+  const handleAddTodo = useCallback(() => {
     if (taskRef.current?.value?.trim()) {
       addTodo({ task: taskRef.current.value })
     }
-  }
+  }, [])
+
   return (
     <div className={styles.container}>
       <div className={styles.wrapperInput}>
@@ -28,14 +28,39 @@ export const AdvancedUsage = () => {
           add
         </button>
       </div>
-      <div className={styles.wrapperCount}>
-        <span>
-          Total: <strong>{todos.length}</strong>
-        </span>
-        <span>
-          Total Finished: <strong>{totalFinished}</strong>
-        </span>
-      </div>
+      <Total />
+      <TotalFinished />
+      <Todo />
+    </div>
+  )
+}
+
+const TotalFinished = () => {
+  const totalFinished = useReStateSelector(countFinishedTodoSelector)
+  return (
+    <div className={styles.wrapperCount}>
+      <span>
+        Total Finished: <strong>{totalFinished}</strong>
+      </span>
+    </div>
+  )
+}
+
+const Total = () => {
+  const countTodo = useReStateSelector(countTodosSelector)
+  return (
+    <div className={styles.wrapperCount}>
+      <span>
+        Total: <strong>{countTodo}</strong>
+      </span>
+    </div>
+  )
+}
+
+const Todo = () => {
+  const todos = useReStateSelector(todosSelector)
+  return (
+    <div>
       {todos.map(todo => (
         <TodoItem key={todo.id} {...todo} />
       ))}
@@ -44,9 +69,9 @@ export const AdvancedUsage = () => {
 }
 
 const TodoItem = (props: TodoItemProps) => {
-  const handleToggleFinished = () => {
+  const handleToggleFinished = useCallback(() => {
     toggleTodo(props.id)
-  }
+  }, [props.id])
   return (
     <div className={styles.todoItem}>
       <p>{props.task}</p>

--- a/examples/src/components/AdvancedUsage/index.tsx
+++ b/examples/src/components/AdvancedUsage/index.tsx
@@ -1,5 +1,5 @@
-import { useCallback, useRef } from 'react'
 import { Selector, useReStateSelector } from '@raulpesilva/re-state'
+import { useCallback, useRef } from 'react'
 import type { TodoList } from '../../states'
 import { addTodo, TodoItemProps, TodoKey, toggleTodo } from '../../states'
 import styles from './index.module.css'

--- a/examples/src/components/SimpleUsage/index.tsx
+++ b/examples/src/components/SimpleUsage/index.tsx
@@ -1,5 +1,4 @@
 import useReState from '@raulpesilva/re-state'
-
 import styles from './index.module.css'
 
 const Foo: React.FC = () => {

--- a/examples/src/components/SimpleUsage/index.tsx
+++ b/examples/src/components/SimpleUsage/index.tsx
@@ -10,10 +10,10 @@ const Foo: React.FC = () => {
       <button
         className={styles.button}
         onClick={() => {
-          setValue(prevValue => prevValue + 1)
+          setValue(value > 0 ? value - 1 : 0)
         }}
       >
-        +
+        -
       </button>
       <p className={styles.display}>
         <span className={styles.text}>Foo - State value: </span>
@@ -22,10 +22,10 @@ const Foo: React.FC = () => {
       <button
         className={styles.button}
         onClick={() => {
-          setValue(value > 0 ? value - 1 : 0)
+          setValue(prevValue => prevValue + 1)
         }}
       >
-        -
+        +
       </button>
     </div>
   )

--- a/examples/src/states/todos/index.ts
+++ b/examples/src/states/todos/index.ts
@@ -3,7 +3,7 @@ import { createReState, createReStateDispatch, createReStateSelect } from '@raul
 export type TodoItemProps = { task: string; id: string; finished: boolean }
 export type TodoList = TodoItemProps[]
 
-const TodoKey = 'todos'
+export const TodoKey = 'todos'
 
 export const useTodoState = createReState<TodoList>(TodoKey, [] as TodoList)
 export const dispatchTodoState = createReStateDispatch<TodoList>(TodoKey)

--- a/examples/src/states/todos/index.ts
+++ b/examples/src/states/todos/index.ts
@@ -10,7 +10,7 @@ export const dispatchTodoState = createReStateDispatch<TodoList>(TodoKey)
 
 export const addTodo = ({ task }: Omit<TodoItemProps, 'id' | 'finished'>) => {
   const newTodo = { id: `todo-${Math.floor(Math.random() * 1000000)}`, finished: false, task }
-  dispatchTodoState(prevTodos => [newTodo, ...prevTodos])
+  dispatchTodoState(prevTodos => [...prevTodos, newTodo])
   return newTodo
 }
 

--- a/examples/yarn.lock
+++ b/examples/yarn.lock
@@ -1437,10 +1437,8 @@
     schema-utils "^2.6.5"
     source-map "^0.7.3"
 
-"@raulpesilva/re-state@1.1.16-beta.0":
-  version "1.1.16-beta.0"
-  resolved "https://registry.yarnpkg.com/@raulpesilva/re-state/-/re-state-1.1.16-beta.0.tgz#f5052a2cd285ba734c3079cebeb9d5ab77bda38e"
-  integrity sha512-jnFyjD5lTR32EjTABax7EB9vfjk9hY3+evThusFtrK5QVUFL2fJEo9rsBOsVyU9E9c6mgoT7FRcnyF+bPE90FQ==
+"@raulpesilva/re-state@file:../dist":
+  version "0.0.0"
 
 "@rollup/plugin-node-resolve@^7.1.1":
   version "7.1.3"

--- a/examples/yarn.lock
+++ b/examples/yarn.lock
@@ -1437,10 +1437,10 @@
     schema-utils "^2.6.5"
     source-map "^0.7.3"
 
-"@raulpesilva/re-state@^1.1.13":
-  version "1.1.13"
-  resolved "https://registry.yarnpkg.com/@raulpesilva/re-state/-/re-state-1.1.13.tgz#b1d36e72b5f84adba3c10c839f26839501f503df"
-  integrity sha512-0ZhD3qhJyuZMMZAYdCR98F4W0tuy71USSBiw/xi551RdEvXpXF9CplkZhPC0hkXwIu5eu3jG6DpeBeNRORKb4w==
+"@raulpesilva/re-state@1.1.16-beta.0":
+  version "1.1.16-beta.0"
+  resolved "https://registry.yarnpkg.com/@raulpesilva/re-state/-/re-state-1.1.16-beta.0.tgz#f5052a2cd285ba734c3079cebeb9d5ab77bda38e"
+  integrity sha512-jnFyjD5lTR32EjTABax7EB9vfjk9hY3+evThusFtrK5QVUFL2fJEo9rsBOsVyU9E9c6mgoT7FRcnyF+bPE90FQ==
 
 "@rollup/plugin-node-resolve@^7.1.1":
   version "7.1.3"
@@ -10953,8 +10953,10 @@ watchpack@^1.7.4:
   resolved "https://registry.yarnpkg.com/watchpack/-/watchpack-1.7.5.tgz#1267e6c55e0b9b5be44c2023aed5437a2c26c453"
   integrity sha512-9P3MWk6SrKjHsGkLT2KHXdQ/9SNkyoJbabxnKOoJepsvJjJG8uYTR3yTPxPQvNDI3w4Nz1xnE0TLHK4RIVe/MQ==
   dependencies:
+    chokidar "^3.4.1"
     graceful-fs "^4.1.2"
     neo-async "^2.5.0"
+    watchpack-chokidar2 "^2.0.1"
   optionalDependencies:
     chokidar "^3.4.1"
     watchpack-chokidar2 "^2.0.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@raulpesilva/re-state",
-  "version": "1.1.16-beta.5",
+  "version": "1.1.16-beta.8",
   "description": "easy way to create a shared state to the entire application",
   "author": "raulpesilva",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,10 +1,11 @@
 {
   "name": "@raulpesilva/re-state",
-  "version": "1.1.14",
+  "version": "1.1.16-beta.0",
   "description": "easy way to create a shared state to the entire application",
   "author": "raulpesilva",
   "license": "MIT",
   "repository": "raulpesilva/re-state",
+  "homepage": "https://restate.vercel.app/",
   "main": "dist/index.js",
   "types": "dist/index.d.js",
   "source": "src/index.tsx",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@raulpesilva/re-state",
-  "version": "1.1.16-beta.0",
+  "version": "1.1.16-beta.1",
   "description": "easy way to create a shared state to the entire application",
   "author": "raulpesilva",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@raulpesilva/re-state",
-  "version": "1.1.16-beta.9",
+  "version": "1.1.16-beta.10",
   "description": "easy way to create a shared state to the entire application",
   "author": "raulpesilva",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@raulpesilva/re-state",
-  "version": "1.1.16-beta.3",
+  "version": "1.1.16-beta.4",
   "description": "easy way to create a shared state to the entire application",
   "author": "raulpesilva",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@raulpesilva/re-state",
-  "version": "1.1.16-beta.2",
+  "version": "1.1.16-beta.3",
   "description": "easy way to create a shared state to the entire application",
   "author": "raulpesilva",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@raulpesilva/re-state",
-  "version": "1.1.16-beta.8",
+  "version": "1.1.16-beta.9",
   "description": "easy way to create a shared state to the entire application",
   "author": "raulpesilva",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@raulpesilva/re-state",
-  "version": "1.1.16-beta.1",
+  "version": "1.1.16-beta.2",
   "description": "easy way to create a shared state to the entire application",
   "author": "raulpesilva",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@raulpesilva/re-state",
-  "version": "1.1.16-beta.10",
+  "version": "1.1.16",
   "description": "easy way to create a shared state to the entire application",
   "author": "raulpesilva",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@raulpesilva/re-state",
-  "version": "1.1.16-beta.4",
+  "version": "1.1.16-beta.5",
   "description": "easy way to create a shared state to the entire application",
   "author": "raulpesilva",
   "license": "MIT",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import { createReState, createReStateDispatch, createReStateSelect, useReState, useReStateSelector } from './package'
 
-export type { Selector, UniqueKey } from './package/types'
+export * from './package/types'
 export { createReStateDispatch, createReState, useReStateSelector, createReStateSelect }
 
 export default useReState

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import { createReState, createReStateDispatch, createReStateSelect, useReState, useReStateSelector } from './package'
 
-export type { Selector, UniqueKey } from './package'
+export type { Selector, UniqueKey } from './package/types'
 export { createReStateDispatch, createReState, useReStateSelector, createReStateSelect }
 
 export default useReState

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,4 +2,6 @@ import { createReState, createReStateDispatch, useReStateSelector, useReState, c
 
 export { createReStateDispatch, createReState, useReStateSelector, createReStateSelect }
 
+export type { UniqueKey, Selector } from './package'
+
 export default useReState

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,6 @@
-import { createReState, createReStateDispatch, useReStateSelector, useReState, createReStateSelect } from './package'
+import { createReState, createReStateDispatch, createReStateSelect, useReState, useReStateSelector } from './package'
 
+export type { Selector, UniqueKey } from './package'
 export { createReStateDispatch, createReState, useReStateSelector, createReStateSelect }
-
-export type { UniqueKey, Selector } from './package'
 
 export default useReState

--- a/src/package/createGetReState.ts
+++ b/src/package/createGetReState.ts
@@ -1,0 +1,6 @@
+import store from './store'
+import { UniqueKey } from './types'
+
+export const createGetReState = <S>(key: UniqueKey) => {
+  return (): S => store.get(key)
+}

--- a/src/package/createReState.ts
+++ b/src/package/createReState.ts
@@ -1,12 +1,10 @@
-import { useDebugValue } from 'react'
 import store from './store'
-import { UniqueKey, SetReStateAction, DispatchReState } from './types'
+import { DispatchReState, SetReStateAction, UniqueKey } from './types'
 import { useReState } from './useReState'
 
 export const createReState = <S>(key: UniqueKey, initialValue?: SetReStateAction<S>) => {
   store.setWithoutNotify(key, initialValue)
   return function useCreatedUseReState(): [S, DispatchReState<SetReStateAction<S>>] {
-    // useDebugValue(store.get(key))
     return useReState<S>(key)
   }
 }

--- a/src/package/createReState.ts
+++ b/src/package/createReState.ts
@@ -6,7 +6,7 @@ import { useReState } from './useReState'
 export const createReState = <S>(key: UniqueKey, initialValue?: SetReStateAction<S>) => {
   store.setWithoutNotify(key, initialValue)
   return function useCreatedUseReState(): [S, DispatchReState<SetReStateAction<S>>] {
-    useDebugValue(store.get(key))
+    // useDebugValue(store.get(key))
     return useReState<S>(key)
   }
 }

--- a/src/package/createReStateDispatch.ts
+++ b/src/package/createReStateDispatch.ts
@@ -1,5 +1,5 @@
 import store from './store'
-import { UniqueKey, SetReStateAction } from './types'
+import { SetReStateAction, UniqueKey } from './types'
 
 export const createReStateDispatch = <S>(key: UniqueKey) => {
   return (value: SetReStateAction<S>) => store.set(key, value)

--- a/src/package/createReStateSelect.ts
+++ b/src/package/createReStateSelect.ts
@@ -1,6 +1,20 @@
+import { useDebugValue, useState } from 'react'
 import store from './store'
 import { UniqueKey } from './types'
+import { useIsomorphicLayoutEffect } from './useIsomorphicLayoutEffect'
 
 export const createReStateSelect = <S>(key: UniqueKey) => {
-  return (): S => store.get(key)
+  const [reStateValue, setReStateValue] = useState<S>(store.get(key))
+
+  useDebugValue(reStateValue)
+
+  useIsomorphicLayoutEffect(() => {
+    const unSub = store.subscribe(key, () => {
+      setReStateValue(store.get(key))
+    })
+
+    return unSub
+  }, [key])
+
+  return reStateValue
 }

--- a/src/package/createReStateSelect.ts
+++ b/src/package/createReStateSelect.ts
@@ -4,17 +4,19 @@ import { UniqueKey } from './types'
 import { useIsomorphicLayoutEffect } from './useIsomorphicLayoutEffect'
 
 export const createReStateSelect = <S>(key: UniqueKey) => {
-  const [reStateValue, setReStateValue] = useState<S>(store.get(key))
+  return function useReStateSelect() {
+    const [reStateValue, setReStateValue] = useState<S>(store.get(key))
 
-  useDebugValue(reStateValue)
+    useDebugValue(reStateValue)
 
-  useIsomorphicLayoutEffect(() => {
-    const unSub = store.subscribe(key, () => {
-      setReStateValue(store.get(key))
-    })
+    useIsomorphicLayoutEffect(() => {
+      const unSub = store.subscribe(key, () => {
+        setReStateValue(store.get(key))
+      })
 
-    return unSub
-  }, [key])
+      return unSub
+    }, [key])
 
-  return reStateValue
+    return reStateValue
+  }
 }

--- a/src/package/index.ts
+++ b/src/package/index.ts
@@ -3,7 +3,6 @@ import { unstable_batchedUpdates as batch } from './reactBatchedUpdates'
 export { createReState } from './createReState'
 export { createReStateDispatch } from './createReStateDispatch'
 export { createReStateSelect } from './createReStateSelect'
-export type { Selector, UniqueKey } from './types'
 export { useReState } from './useReState'
 export { useReStateSelector } from './useReStateSelector'
 setBatch(batch)

--- a/src/package/index.ts
+++ b/src/package/index.ts
@@ -5,4 +5,5 @@ export { createReStateDispatch } from './createReStateDispatch'
 export { createReStateSelect } from './createReStateSelect'
 export { useReState } from './useReState'
 export { useReStateSelector } from './useReStateSelector'
+export type { UniqueKey, Selector } from './types'
 setBatch(batch)

--- a/src/package/index.ts
+++ b/src/package/index.ts
@@ -3,7 +3,7 @@ import { unstable_batchedUpdates as batch } from './reactBatchedUpdates'
 export { createReState } from './createReState'
 export { createReStateDispatch } from './createReStateDispatch'
 export { createReStateSelect } from './createReStateSelect'
+export type { Selector, UniqueKey } from './types'
 export { useReState } from './useReState'
 export { useReStateSelector } from './useReStateSelector'
-export type { UniqueKey, Selector } from './types'
 setBatch(batch)

--- a/src/package/listener.ts
+++ b/src/package/listener.ts
@@ -1,9 +1,9 @@
 import { FnVoid } from './types'
 
 class Listener {
-  _listeners: FnVoid[] = []
+  _listeners: ((state: any) => void)[] = []
 
-  subscribe(listener: FnVoid): FnVoid {
+  subscribe(listener: (state: any) => void): FnVoid {
     this._listeners.push(listener)
     return (): void => {
       const index = this._listeners.indexOf(listener)
@@ -14,9 +14,9 @@ class Listener {
     }
   }
 
-  notify(): void {
+  notify(state: any): void {
     for (const listener of this._listeners) {
-      listener()
+      listener(state)
     }
   }
 }

--- a/src/package/listener.ts
+++ b/src/package/listener.ts
@@ -1,9 +1,9 @@
 import { FnVoid } from './types'
 
 class Listener {
-  _listeners: ((state: any) => void)[] = []
+  _listeners: ((prevStore: any, newStore: any) => void)[] = []
 
-  subscribe(listener: (state: any) => void): FnVoid {
+  subscribe(listener: (prevStore: any, newStore: any) => void): FnVoid {
     this._listeners.push(listener)
     return (): void => {
       const index = this._listeners.indexOf(listener)
@@ -14,9 +14,9 @@ class Listener {
     }
   }
 
-  notify(state: any): void {
+  notify(prevStore: any, newStore: any): void {
     for (const listener of this._listeners) {
-      listener(state)
+      listener(prevStore, newStore)
     }
   }
 }

--- a/src/package/observer.ts
+++ b/src/package/observer.ts
@@ -1,4 +1,4 @@
-import { UniqueKey, SetReStateAction, FnVoid } from './types'
+import { FnVoid, SetReStateAction, UniqueKey } from './types'
 
 class Observer {
   _listeners = new Map()

--- a/src/package/store.ts
+++ b/src/package/store.ts
@@ -18,10 +18,10 @@ class Store {
   }
 
   set<S>(key: UniqueKey, newValue: S): void {
-    const prevValue = this.get<S>(key)
+    const prevState = this.get<S>(key)
 
     if (typeof newValue === 'function') {
-      this.__store.set(key, newValue(prevValue))
+      this.__store.set(key, newValue(prevState))
     } else {
       this.__store.set(key, newValue)
     }
@@ -29,7 +29,7 @@ class Store {
     const batch = getBatch()
     batch(() => {
       this.notify(key)
-      this.notifySelectors()
+      this.notifySelectors(prevState)
     })
   }
 
@@ -57,9 +57,8 @@ class Store {
     return fn(objectStore)
   }
 
-  notifySelectors() {
-    const objectStore = Store.convertStoreToObject(this.__store)
-    this.__listener.notify(objectStore)
+  notifySelectors(prevState: any) {
+    this.__listener.notify(prevState)
   }
 
   subscribeSelector(listener: (state: any) => void) {

--- a/src/package/store.ts
+++ b/src/package/store.ts
@@ -1,7 +1,7 @@
 import { getBatch } from './batch'
 import Listener from './listener'
 import Observer from './observer'
-import { UniqueKey, FnVoid } from './types'
+import { FnVoid, UniqueKey } from './types'
 import { isFunction } from './utils'
 class Store {
   __store = new Map<UniqueKey, unknown>()

--- a/src/package/store.ts
+++ b/src/package/store.ts
@@ -58,10 +58,11 @@ class Store {
   }
 
   notifySelectors() {
-    this.__listener.notify()
+    const objectStore = Store.convertStoreToObject(this.__store)
+    this.__listener.notify(objectStore)
   }
 
-  subscribeSelector(listener: FnVoid) {
+  subscribeSelector(listener: (state: any) => void) {
     return this.__listener.subscribe(listener)
   }
 

--- a/src/package/store.ts
+++ b/src/package/store.ts
@@ -19,6 +19,7 @@ class Store {
 
   set<S>(key: UniqueKey, newValue: S): void {
     const prevState = this.get<S>(key)
+    const { ...prevStore } = Store.convertStoreToObject(this.__store)
 
     if (typeof newValue === 'function') {
       this.__store.set(key, newValue(prevState))
@@ -26,10 +27,12 @@ class Store {
       this.__store.set(key, newValue)
     }
 
+    const { ...newStore } = Store.convertStoreToObject(this.__store)
+
     const batch = getBatch()
     batch(() => {
       this.notify(key)
-      this.notifySelectors(prevState)
+      this.notifySelectors(prevStore, newStore)
     })
   }
 
@@ -57,11 +60,11 @@ class Store {
     return fn(objectStore)
   }
 
-  notifySelectors(prevState: any) {
-    this.__listener.notify(prevState)
+  notifySelectors(prevStore: any, newStore: any) {
+    this.__listener.notify(prevStore, newStore)
   }
 
-  subscribeSelector(listener: (state: any) => void) {
+  subscribeSelector(listener: (prevStore: any, newStore: any) => void) {
     return this.__listener.subscribe(listener)
   }
 

--- a/src/package/types.ts
+++ b/src/package/types.ts
@@ -1,7 +1,5 @@
 export type UniqueKey = string | symbol
-export type IStore<T> = { [key: string]: T }
-export type voidFunction = () => void
-export type batchCallback = (callback: () => any) => void
 export type DispatchReState<A> = (value: A) => void
 export type SetReStateAction<S> = S | ((prevState: S) => S) | undefined
 export type FnVoid = () => void
+export type Selector<T, S = T> = (store: T) => S

--- a/src/package/useIsomorphicLayoutEffect.ts
+++ b/src/package/useIsomorphicLayoutEffect.ts
@@ -1,4 +1,4 @@
-import { useLayoutEffect, useEffect } from 'react'
+import { useEffect, useLayoutEffect } from 'react'
 
 export const useIsomorphicLayoutEffect =
   typeof window !== 'undefined' &&

--- a/src/package/useReState.ts
+++ b/src/package/useReState.ts
@@ -1,6 +1,6 @@
 import { useCallback, useDebugValue, useState } from 'react'
 import store from './store'
-import { UniqueKey, SetReStateAction, DispatchReState } from './types'
+import { DispatchReState, SetReStateAction, UniqueKey } from './types'
 import { useIsomorphicLayoutEffect } from './useIsomorphicLayoutEffect'
 
 export const useReState = <S>(

--- a/src/package/useReState.ts
+++ b/src/package/useReState.ts
@@ -1,4 +1,4 @@
-import { useDebugValue, useState } from 'react'
+import { useCallback, useDebugValue, useState } from 'react'
 import store from './store'
 import { UniqueKey, SetReStateAction, DispatchReState } from './types'
 import { useIsomorphicLayoutEffect } from './useIsomorphicLayoutEffect'
@@ -7,30 +7,33 @@ export const useReState = <S>(
   key: UniqueKey,
   initialValue?: SetReStateAction<S>
 ): [S, DispatchReState<SetReStateAction<S>>] => {
-  const [, setReRender] = useState({})
+  const makeState = useCallback(
+    (value: SetReStateAction<S>): S => {
+      if (store.has(key)) {
+        return store.get<S>(key)
+      } else {
+        store.setWithoutNotify<SetReStateAction<S>>(key, value)
+        return store.get<S>(key)
+      }
+    },
+    [key]
+  )
 
-  const setState = (newValue: SetReStateAction<S>) => {
-    store.set<SetReStateAction<S>>(key, newValue)
-    setReRender({})
-  }
+  const setState = useCallback(
+    (newValue: SetReStateAction<S>) => {
+      store.set<SetReStateAction<S>>(key, newValue)
+    },
+    [key]
+  )
 
-  const reRender = (): void => {
-    setReRender({})
-  }
-
-  const makeState = (value: SetReStateAction<S>): S => {
-    if (store.has(key)) {
-      return store.get<S>(key)
-    } else {
-      store.setWithoutNotify<SetReStateAction<S>>(key, value)
-      return store.get<S>(key)
-    }
-  }
+  const [reStateValue, setReStateValue] = useState<S>(makeState(initialValue))
 
   useDebugValue(makeState(initialValue))
 
   useIsomorphicLayoutEffect(() => {
-    const unSub = store.subscribe(key, reRender)
+    const unSub = store.subscribe(key, () => {
+      setReStateValue(store.get(key))
+    })
 
     if (!store.has(key) && initialValue) {
       store.set<SetReStateAction<S>>(key, initialValue)
@@ -39,6 +42,5 @@ export const useReState = <S>(
     return unSub
   }, [initialValue, key])
 
-  const value = makeState(initialValue)
-  return [value, setState]
+  return [reStateValue, setState]
 }

--- a/src/package/useReStateSelector.ts
+++ b/src/package/useReStateSelector.ts
@@ -1,10 +1,10 @@
 import { useCallback, useDebugValue, useRef, useState } from 'react'
 import store from './store'
-import { IStore } from './types'
+import { Selector } from './types'
 import { useIsomorphicLayoutEffect } from './useIsomorphicLayoutEffect'
 import { shallowEqual } from './utils'
 
-export const useReStateSelector = <T>(selector = (store: IStore<T>): any => store, isEquals = shallowEqual): T => {
+export const useReStateSelector = <T, S = T>(selector: Selector<T, S>, isEquals = shallowEqual): S => {
   const prevState = useRef(store.getMany(selector))
   const [, setReRender] = useState({})
 
@@ -15,16 +15,16 @@ export const useReStateSelector = <T>(selector = (store: IStore<T>): any => stor
     setReRender({})
   }, [isEquals, selector])
 
-  useDebugValue(store.getMany<T>(selector))
+  useDebugValue(store.getMany<S>(selector))
 
   useIsomorphicLayoutEffect(() => {
     const unSub = store.subscribeSelector(() => {
-      store.getMany<T>(selector)
+      store.getMany<S>(selector)
       reRender()
     })
 
     return unSub
   }, [selector, reRender])
 
-  return store.getMany<T>(selector)
+  return store.getMany<S>(selector)
 }

--- a/src/package/useReStateSelector.ts
+++ b/src/package/useReStateSelector.ts
@@ -19,8 +19,8 @@ export const useReStateSelector = <T, S = T>(selector: Selector<T, S>, isEquals 
   useDebugValue(selectorValue)
 
   useIsomorphicLayoutEffect(() => {
-    const unSub = store.subscribeSelector((state: S) => {
-      reRender(state)
+    const unSub = store.subscribeSelector((state: T) => {
+      reRender(selector(state))
     })
 
     return unSub

--- a/src/package/useReStateSelector.ts
+++ b/src/package/useReStateSelector.ts
@@ -1,4 +1,4 @@
-import { useCallback, useDebugValue, useState } from 'react'
+import { useDebugValue, useState } from 'react'
 import store from './store'
 import { Selector } from './types'
 import { useIsomorphicLayoutEffect } from './useIsomorphicLayoutEffect'
@@ -7,24 +7,19 @@ import { shallowEqual } from './utils'
 export const useReStateSelector = <T, S = T>(selector: Selector<T, S>, isEquals = shallowEqual): S => {
   const [selectorValue, setSelectorValue] = useState<S>(store.getMany(selector))
 
-  const reRender = useCallback(
-    (prevState: S) => {
-      if (!isEquals(prevState, store.getMany<S>(selector))) {
-        setSelectorValue(store.getMany<S>(selector))
-      }
-    },
-    [isEquals, selector]
-  )
-
   useDebugValue(selectorValue)
 
   useIsomorphicLayoutEffect(() => {
-    const unSub = store.subscribeSelector((state: T) => {
-      reRender(selector(state))
+    const unSub = store.subscribeSelector((prevStore: T, newStore: T) => {
+      const prevSelection = selector(prevStore)
+      const newSelection = selector(newStore)
+      if (!isEquals(prevSelection, newSelection)) {
+        setSelectorValue(newSelection)
+      }
     })
 
     return unSub
-  }, [selector, reRender])
+  }, [selector])
 
   return selectorValue
 }

--- a/src/package/useReStateSelector.ts
+++ b/src/package/useReStateSelector.ts
@@ -1,4 +1,4 @@
-import { useCallback, useDebugValue, useRef, useState } from 'react'
+import { useCallback, useDebugValue, useState } from 'react'
 import store from './store'
 import { Selector } from './types'
 import { useIsomorphicLayoutEffect } from './useIsomorphicLayoutEffect'

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,7 @@
     "declaration": true,
     "skipLibCheck": true,
     "removeComments": true,
-    "isolatedModules": true,
+    // "isolatedModules": true,
     "esModuleInterop": true,
     "strictNullChecks": true,
     "resolveJsonModule": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,10 +1,10 @@
 {
   "compilerOptions": {
     // "noEmit": true,
-    "module": "commonjs",
+    "module": "esnext",
     "strict": true,
-    "allowJs": true,
-    "target": "es6",
+    // "allowJs": true,
+    "target": "esnext",
     "sourceMap": true,
     "outDir": "dist",
     "jsx": "react-jsx",
@@ -19,8 +19,8 @@
     "noFallthroughCasesInSwitch": true,
     "allowSyntheticDefaultImports": true,
     "forceConsistentCasingInFileNames": true,
-    "lib": ["dom", "dom.iterable", "esnext"]
+    "lib": ["dom", "esnext"]
   },
   "include": ["src/**/*", "./src/package/typings.d.ts"],
-  "exclude": ["node_modules", "dist", "examples"]
+  "exclude": ["node_modules", "dist", "examples", "assets"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,7 @@
     "declaration": true,
     "skipLibCheck": true,
     "removeComments": true,
-    // "isolatedModules": true,
+    "isolatedModules": true,
     "esModuleInterop": true,
     "strictNullChecks": true,
     "resolveJsonModule": true,


### PR DESCRIPTION
- fix: remove unused types and fix type useSelector
- chore: update advanced example and re-state, change basic buttons orders
- docs: update createReState with new type
- Revert "docs: update createReState with new type"
- docs: update useReStateSelector with new type
- fix: useSelector and update example
- chore(docs): prettier and update docs reStateSelector
- docs: update example readme
- hotfix: export type
- hotfix: remove flag isoletedModules of tsconfig
- hotfix: export all types
- hotfix: useSelector isEqual params
- hotfix: previousState
- fix: useSelector updates
- chore: update package version
- feature: changelog and createGetReState
- hotfix: createReStateSelect to return a hook
- chore: update package version and changelog
